### PR TITLE
Fix: Root path redirects to home for authenticated users

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,14 +1,16 @@
-/** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest',
-  testEnvironment: 'jest-environment-jsdom',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['@testing-library/jest-dom'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
-  setupFilesAfterEnv: ['./jest.setup.js', '@testing-library/jest-dom'],
-  globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig.app.json',
-    },
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: 'tsconfig.app.json',
+      },
+    ],
   },
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { UserProvider } from "./contexts/UserContext";
 import { SessionProvider } from "./contexts/SessionContext";
 import { TimerProvider } from "./contexts/TimerContext";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
+import RootRedirect from './components/auth/RootRedirect';
 
 import HomePage from "./pages/HomePage";
 import RegistrationPage from "./pages/RegistrationPage";
@@ -37,7 +38,7 @@ const App = () => {
               <SessionProvider>
                 <TimerProvider>
                   <Routes>
-                    <Route path="/" element={<Navigate to="/login" replace />} />
+                    <Route path="/" element={<RootRedirect />} />
                     <Route path="/login" element={<LoginPage />} />
                     <Route path="/register" element={<RegistrationPage />} />
                     <Route path="/home" element={

--- a/src/components/auth/RootRedirect.test.tsx
+++ b/src/components/auth/RootRedirect.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route, useLocation } from "react-router-dom";
+import RootRedirect from "./RootRedirect";
+import { useUser } from "@/contexts/UserContext";
+
+// Mock the useUser hook
+jest.mock("@/contexts/UserContext", () => ({
+  useUser: jest.fn(),
+}));
+
+// Helper component to display the current location
+const LocationDisplay = () => {
+  const location = useLocation();
+  return <div data-testid="location-display">{location.pathname}</div>;
+};
+
+describe("RootRedirect", () => {
+  it("redirects to /home when authenticated", () => {
+    (useUser as jest.Mock).mockReturnValue({ isAuthenticated: true });
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route path="/" element={<RootRedirect />} />
+          <Route path="/home" element={<LocationDisplay />} />
+          <Route path="/login" element={<LocationDisplay />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByTestId("location-display")).toHaveTextContent("/home");
+  });
+
+  it("redirects to /login when not authenticated", () => {
+    (useUser as jest.Mock).mockReturnValue({ isAuthenticated: false });
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route path="/" element={<RootRedirect />} />
+          <Route path="/home" element={<LocationDisplay />} />
+          <Route path="/login" element={<LocationDisplay />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByTestId("location-display")).toHaveTextContent("/login");
+  });
+});

--- a/src/components/auth/RootRedirect.tsx
+++ b/src/components/auth/RootRedirect.tsx
@@ -1,0 +1,14 @@
+import { Navigate } from "react-router-dom";
+import { useUser } from "@/contexts/UserContext";
+
+const RootRedirect = () => {
+  const { isAuthenticated } = useUser();
+
+  if (isAuthenticated) {
+    return <Navigate to="/home" replace />;
+  } else {
+    return <Navigate to="/login" replace />;
+  }
+};
+
+export default RootRedirect;


### PR DESCRIPTION
Previously, the root path ("/") always redirected to "/login". This change introduces a new `RootRedirect` component that handles the redirection based on your authentication status.

- If you are authenticated, you are redirected to "/home".
- If you are not authenticated, you are redirected to "/login".

Unit tests have been added for the `RootRedirect` component to ensure this logic is correctly implemented.